### PR TITLE
page builder and view block fix - vue-grid-layout update

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "v-tooltip": "^2.0.0-rc.33",
     "vue": "^2.5.17",
     "vue-events": "^3.1.0",
-    "vue-grid-layout": "^2.2.0",
+    "vue-grid-layout": "^2.3.1",
     "vue-multiselect": "^2.1.3",
     "vue-router": "^3.0.1",
     "vuedraggable": "^2.16.0",

--- a/src/components/PageContent.vue
+++ b/src/components/PageContent.vue
@@ -1,18 +1,17 @@
 <template>
   <div class="view-grid" v-bind:class="{ 'mobile': !wide }">
-    <grid-layout v-if="blocks && blocks.length > 0" :layout="blocks" :col-num="viewPageColNum" :row-height="90" :is-draggable="false" :is-resizable="false" :vertical-compact="true" :use-css-transforms="true">
-      <grid-item v-for="block in blocks" v-bind:key="block.i" :x="block.x" :y="block.y" :w="block.w" :h="block.h" :i="block.i" v-bind:is-draggable="false">
+    <grid-layout v-if="layout && layout.length > 0" :layout="layout" :col-num="colNum" :row-height="90" :is-draggable="false" :is-resizable="false" :vertical-compact="true" :use-css-transforms="true">
+      <grid-item v-for="block in layout" v-bind:key="block.i" :x="block.x" :y="block.y" :w="block.w" :h="block.h" :i="block.i" v-bind:is-draggable="false">
         <Block :block="block"></Block>
       </grid-item>
     </grid-layout>
-    <div style="color:red;" v-if="!blocks || blocks.length == 0">
+    <div style="color:red;" v-if="!layout || layout.length == 0">
       This page has no blocks
     </div>
   </div>
 </template>
 
 <script>
-import { mapState, mapActions } from 'vuex'
 /* eslint-disable-next-line */
 import VueGridLayout from "vue-grid-layout";
 import Block from '@/components/block/Block'
@@ -20,6 +19,9 @@ export default {
   name: 'PageContent',
   components: {
     Block,
+  },
+  props: {
+    layout: [],
   },
   data () {
     return {
@@ -29,6 +31,10 @@ export default {
         width: 0,
         height: 0,
       },
+      draggable: true,
+      resizable: true,
+      colNum: 12,
+      blocks: null,
     }
   },
   created () {
@@ -38,31 +44,16 @@ export default {
   destroyed () {
     window.removeEventListener('resize', this.handleResize)
   },
-  computed: {
-    ...mapState({
-      viewPageData: state => state.pages.viewPageData,
-      viewPageColNum: state => state.pages.viewPageColNum,
-      pages: state => state.pages.list,
-    }),
-    blocks () {
-      if (this.wide) {
-        return this.$store.state.pages.viewPageData.blocks
-      } else {
-        return this.$store.state.pages.viewPageData.mobileBlocks
-      }
-    },
-  },
   methods: {
-    ...mapActions('pages', []),
     handleResize () {
       this.window.width = window.innerWidth
       this.window.height = window.innerHeight
       if (this.window.width > this.wideWidth) {
         this.wide = true
-        this.$store.commit('pages/setViewPageColNum', 2)
+        this.colNum = 12
       } else {
         this.wide = false
-        this.$store.commit('pages/setViewPageColNum', 1)
+        this.colNum = 1
       }
     },
   },

--- a/src/components/builder/BuilderGrid.vue
+++ b/src/components/builder/BuilderGrid.vue
@@ -32,7 +32,8 @@ export default {
     return {
       draggable: true,
       resizable: true,
-      colNum: 2,
+      colNum: 12,
+      mobilePreview: false,
     }
   },
   methods: {

--- a/src/views/Builder.vue
+++ b/src/views/Builder.vue
@@ -34,7 +34,7 @@ export default {
         w: 1,
         h: 1,
         y: 0,
-        colNum: 2,
+        colNum: 4,
       },
       addBlockFormData: {},
       addBlockFormMeta: {},
@@ -61,7 +61,7 @@ export default {
       this.pageData = await this.$root.$crm.pageRead({ 'pageID': this.$route.query.pageId })
 
       // check if there are any blocks to add
-      if (this.pageData.blocks) {
+      if (this.pageData.blocks != null && this.pageData.blocks.length > 0) {
         this.layout = SharedService.cloneObject(this.pageData.blocks)
 
         // rebuild the fields that have been added
@@ -84,6 +84,8 @@ export default {
             })
           }
         })
+      } else {
+        this.layout = []
       }
     },
     addNewBlock (value) {

--- a/src/views/Pages/View.vue
+++ b/src/views/Pages/View.vue
@@ -1,18 +1,67 @@
 <template>
-  <PageContent></PageContent>
+  <PageContent :layout=layout></PageContent>
 </template>
 
 <script>
 /* eslint-disable-next-line */
-import VueGridLayout from "vue-grid-layout";
+import VueGridLayout from 'vue-grid-layout'
 import PageContent from '@/components/PageContent'
+
+import SharedService from '@/services/SharedService'
+
 export default {
   name: 'PageView',
   components: {
     PageContent,
   },
+  data () {
+    return {
+      pageData: {},
+      layout: [],
+    }
+  },
   created () {
-    this.$store.dispatch('pages/initViewPageData', this.$route.params.id)
+    this.fetchPage()
+  },
+  methods: {
+    async fetchPage () {
+      // await this.$store.dispatch('builder/fetchPageData', this.$route.query.pageId)
+      this.pageData = await this.$root.$crm.pageRead({
+        pageID: this.$route.params.id,
+      })
+
+      if (this.pageData.id === '0') {
+        throw new Error('No id')
+      }
+
+      // check if there are any blocks to add
+      if (this.pageData.blocks && this.pageData.blocks.length > 0) {
+        this.layout = SharedService.cloneObject(this.pageData.blocks)
+
+        // rebuild the fields that have been added
+        this.layout.forEach(function (block, blockInder) {
+          block.content.fields = []
+
+          // go through all fields (if any)
+          if (block.content.fieldsID) {
+            block.content.fields = []
+            block.content.fieldsID.forEach(function (field, fieldIndex) {
+              // find the corrosponding field in the module
+              var f = block.content.module.fields.find(x => x.id === field)
+              if (f) {
+                // we found the field so copy it to the content.fields array
+                block.content.fields.push(SharedService.cloneObject(f))
+              } else {
+                // the field was not found. Maybe the module has changed?
+                alert(`Column ID ${field} in block not found`)
+              }
+            })
+          }
+        })
+      } else {
+        this.layout = []
+      }
+    },
   },
 }
 </script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9805,10 +9805,10 @@ vue-functional-data-merge@^2.0.5:
   resolved "https://registry.yarnpkg.com/vue-functional-data-merge/-/vue-functional-data-merge-2.0.7.tgz#bdee655181eacdcb1f96ce95a4cc14e75313d1da"
   integrity sha512-pvLc+H+x2prwBj/uSEIITyxjz/7ZUVVK8uYbrYMmhDvMXnzh9OvQvVEwcOSBQjsubd4Eq41/CSJaWzy4hemMNQ==
 
-vue-grid-layout@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/vue-grid-layout/-/vue-grid-layout-2.2.0.tgz#91d7b51739b15033e9cec3b568b7be61d0a088d6"
-  integrity sha512-jwq+Ko3Bs7ocv7SPAD769Cox7JHRf91ewFqSEWu4esAwUsSorZL7JM5o0K/vTRj7yZCdjY/JSu2vBCC+dyC+Og==
+vue-grid-layout@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/vue-grid-layout/-/vue-grid-layout-2.3.1.tgz#db7240defc5c90036ba527d5526041b8c492e741"
+  integrity sha512-jkj0ckrAYTM1qfijlSRqp001KhrXRD7DP79KeFQr8JGe9BCcEf4vNGEbk1t5jC5VL9IfUEy24pmke36CCa67wg==
   dependencies:
     element-resize-detector "^1.1.10"
     interactjs "^1.3.4"


### PR DESCRIPTION
1) Fixed issue on not being able to add blocks to a newly created page
2) Fixed warning being thrown about mobilePreview
3) Removed vuex store from Page View
4) changed column widths from 2 to 12 in the layout
5) updated vue-grid-layout from 2.2.0 to 2.3.1