### PR TITLE
Fix admin navbar collapse

### DIFF
--- a/src/components/Admin/Header.vue
+++ b/src/components/Admin/Header.vue
@@ -1,13 +1,13 @@
 <template>
   <header>
-    <b-navbar toggleable="lg" type="light">
+    <b-navbar toggleable="md" type="light">
         <b-navbar-toggle target="admin_nav_collapse">
           <label
             class="channel-toggle">
             <i class="icon-menu4"></i>
           </label>
         </b-navbar-toggle>
-        <b-collapse is-nav id="admin_nav_collapse">
+        <b-collapse is-nav id="admin_nav_collapse" :class="{ visible }" @show="toggleNav(true)" @hide="toggleNav(false)">
           <ul>
             <li>
               <router-link :to="{name: 'admin.modules'}" class="nav-link">{{ $t('navigation.module') }}</router-link>
@@ -29,6 +29,14 @@
     </b-navbar>
   </header>
 </template>
+
+<script>
+import navbarCollapse from '@/mixins/navbar_collapse'
+
+export default {
+  mixins: [ navbarCollapse ],
+}
+</script>
 
 <style lang="scss" scoped>
 @import "@/assets/sass/components/header.scss";
@@ -58,7 +66,7 @@ ul {
   max-width: 100%;
 }
 
-@media (max-width: 991px) {
+@media (max-width: 768px) {
   ul {
     position: relative;
 

--- a/src/components/Public/Header.vue
+++ b/src/components/Public/Header.vue
@@ -26,6 +26,7 @@
 <script>
 import { mapGetters } from 'vuex'
 import MenuLevel from './MenuLevel'
+import navbarCollapse from '@/mixins/navbar_collapse'
 
 const collapserWidth = 55
 
@@ -33,6 +34,8 @@ export default {
   components: {
     MenuLevel,
   },
+
+  mixins: [ navbarCollapse ],
 
   props: {
     currentPageID: {
@@ -43,7 +46,6 @@ export default {
   data () {
     return {
       tree: [],
-      visible: false,
       collapsedCount: 0,
     }
   },
@@ -101,11 +103,6 @@ export default {
   },
 
   methods: {
-    toggleNav (visible) {
-      this.visible = visible
-      this.$emit('toggleNav', visible)
-    },
-
     collapser (nav, bb, collapse, extraOffset, rightOffset) {
       const { children: nChildren = new HTMLCollection() } = nav
       const collapseBody = collapse.getElementsByTagName('UL')[0]

--- a/src/mixins/navbar_collapse.js
+++ b/src/mixins/navbar_collapse.js
@@ -1,0 +1,14 @@
+export default {
+  data () {
+    return {
+      visible: false,
+    }
+  },
+
+  methods: {
+    toggleNav (visible) {
+      this.visible = visible
+      this.$emit('toggleNav', visible)
+    },
+  },
+}


### PR DESCRIPTION
Administration navbar had weird behaviour on smaller screens.
 * on <900px or so, the nav expanded from top instead from left
 * on < 700px or so, the nav didn't want to expand.